### PR TITLE
HDMA should not start during HBLANK. Fixes Donkey Kong Country.

### DIFF
--- a/components/gnuboy/hw.c
+++ b/components/gnuboy/hw.c
@@ -123,8 +123,10 @@ void hw_hdma_cmd(byte c)
 		div_advance(advance << cpu.speed);
 		timer_advance(advance << cpu.speed);
 		sound_advance(advance);
-		
-		if ((R_STAT&0x03) == 0x00) hw_hdma(); /* SEE COMMENT A ABOVE */
+
+		/* FIXME: according to docs, hdma should not be started during hblank
+		(Extreme Ghostbusters game does, but it also works without this line) */
+		/*if ((R_STAT&0x03) == 0x00) hw_hdma();*/ /* SEE COMMENT A ABOVE */
 		return;
 	}
 	


### PR DESCRIPTION
So while i was working on my own Gnuboy fork and tried to merge an upstream fix for Killer Instinct,
i broke DKC.
After some testing, i've found that disabling this exact line fixed the game while still allowing Killer Instinct & Extreme Ghostbusters to work.
Upstream also had a note with it basically saying that it was probably not needed... really.

As soon as it was disabled, Donkey Kong Country started to work without glitchy graphics ingame.